### PR TITLE
Fix sewing hole spacing to include margin spacing (v1.4.8)

### DIFF
--- a/booklet-processor.js
+++ b/booklet-processor.js
@@ -356,29 +356,31 @@ class DocumentProcessor {
                 // Margin from cutting lines for sewing holes
                 const sewingMargin = 25;  // 25pt margin from cutting lines
 
-                // Top pages: span from topCutY down to horizontalCutY
+                // Top pages: boundaries are from topCutY down to horizontalCutY
                 const topPagesTop = topCutY - sewingMargin;
                 const topPagesBottom = horizontalCutY + sewingMargin;
                 const topAvailableSpace = topPagesTop - topPagesBottom;
-                const topSpacing = numHoles > 1 ? topAvailableSpace / (numHoles - 1) : 0;
 
-                // Bottom pages: span from horizontalCutY down to bottomCutY
+                // Bottom pages: boundaries are from horizontalCutY down to bottomCutY
                 const bottomPagesTop = horizontalCutY - sewingMargin;
                 const bottomPagesBottom = bottomCutY + sewingMargin;
                 const bottomAvailableSpace = bottomPagesTop - bottomPagesBottom;
-                const bottomSpacing = numHoles > 1 ? bottomAvailableSpace / (numHoles - 1) : 0;
+
+                // Calculate spacing: divide by (numHoles + 1) for equal spacing including margins
+                const topSpacing = topAvailableSpace / (numHoles + 1);
+                const bottomSpacing = bottomAvailableSpace / (numHoles + 1);
 
                 const allHoles = [];
 
-                // Top pages holes (working down from topPagesTop)
-                for (let hole = 0; hole < numHoles; hole++) {
-                    const yPos = topPagesTop - (hole * topSpacing);
+                // Top pages holes: start from bottom margin and work UP
+                for (let hole = 1; hole <= numHoles; hole++) {
+                    const yPos = topPagesBottom + (hole * topSpacing);
                     allHoles.push(yPos);
                 }
 
-                // Bottom pages holes (working down from bottomPagesTop)
-                for (let hole = 0; hole < numHoles; hole++) {
-                    const yPos = bottomPagesTop - (hole * bottomSpacing);
+                // Bottom pages holes: start from bottom margin and work UP
+                for (let hole = 1; hole <= numHoles; hole++) {
+                    const yPos = bottomPagesBottom + (hole * bottomSpacing);
                     allHoles.push(yPos);
                 }
 

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         <header>
             <h1>Document Processor</h1>
             <p>PDF booklet processing and EPUB cover updating</p>
-            <div class="version-info">v1.4.7</div>
+            <div class="version-info">v1.4.8</div>
         </header>
 
         <main>


### PR DESCRIPTION
Improved sewing hole calculation for perfect even spacing:

Old method:
- spacing = totalSpace / (numHoles - 1)
- First hole AT bottom boundary, last hole AT top boundary
- No spacing at margins

New method (holes + 1):
- spacing = totalSpace / (numHoles + 1)
- Start from bottom margin, add spacing for each hole
- Creates equal spacing INCLUDING margins

Example with 4 holes, 500pt space:
- spacing = 500 / 5 = 100pt
- Hole 1: bottomMargin + 100
- Hole 2: bottomMargin + 200
- Hole 3: bottomMargin + 300
- Hole 4: bottomMargin + 400
- Result: [margin]-100-[hole]-100-[hole]-100-[hole]-100-[hole]-100-[margin]

Benefits:
✓ Equal spacing between ALL elements (margins and holes) ✓ Professional appearance
✓ Both page pairs use same spacing formula
✓ Symmetric when folded

🤖 Generated with [Claude Code](https://claude.com/claude-code)